### PR TITLE
Restore: files from the original repo.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,112 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true #Changed
+AlignConsecutiveDeclarations: true #Changed
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false # Changed
+#AllowAllArgumentsOnNextLine: false # Changed
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline #Changed
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true #Changed
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true #Changed
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true #Changed
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false #Changed
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom #Changed
+BreakBeforeInheritanceComma: false 
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false 
+BreakConstructorInitializers: AfterColon      #Changed
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120 #Changed
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true #Changed 
+ConstructorInitializerIndentWidth: 2 #Changed
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true #Changed
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left #Changed
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp03 #Changed
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,38 @@
+---
+# All Clang-Tidy Checks allowed, except:
+# - forbidden vararg
+# - forbidden magic numbers
+# - forbidden namespace "using"
+# - forbidden array->pointer decay
+# - init of static memory may cause an exception (cert-err58)
+# - forbidden implicit conversion from pointer/int to bool
+# - recommended auto
+# - remove llvm-specific checks (header guard style, usage of llvm namespace, restriction of libc includes, etc.)
+# Naming conventions set to snake_case
+Checks: '*,-fuchsia-*,
+         -cppcoreguidelines-pro-type-vararg,-hicpp-vararg,
+         -cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,
+         -cppcoreguidelines-pro-bounds-array-to-pointer-decay,-hicpp-no-array-decay,
+         -cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-type-cstyle-cast,
+         -cppcoreguidelines-pro-type-union-access,
+         -cppcoreguidelines-pro-type-static-cast-downcast,
+         -modernize-use-using,-modernize-use-trailing-return-type,
+         -modernize-use-auto,-hicpp-use-auto,
+         -llvmlibc-callee-namespace,-llvmlibc-implementation-in-namespace,-llvmlibc-restrict-system-libc-headers,
+         -llvm-header-guard,
+         -google-runtime-references,-google-readability-casting,-google-build-using-namespace,
+         google-default-arguments,-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+         -cert-err58-cpp,
+         -altera-unroll-loops,
+         -readability-function-cognitive-complexity,-readability-isolate-declaration,
+         -misc-non-private-member-variables-in-classes,-altera-struct-pack-align,-readability-uppercase-literal-suffix,
+         -cppcoreguidelines-non-private-member-variables-in-classes,
+         readability-identifier-naming'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+  - { key: readibility-identifier-naming.ClassCase,     value: lower_case }
+  - { key: readibility-identifier-naming.StructCase,    value: lower_case }
+  - { key: readibility-identifier-naming.VariableCase,  value: lower_case }
+


### PR DESCRIPTION
These are copied directly from https://github.com/srsran/srsRAN_4G. They support using the clang-tidy and clang-format tools to ensure our code matches the style SRS used.