### PR TITLE
targeted fuzzing branch

### DIFF
--- a/srsue/hdr/stack/rrc/rrc_config.h
+++ b/srsue/hdr/stack/rrc/rrc_config.h
@@ -42,6 +42,7 @@ struct rrc_args_t {
   int                                     mbms_service_id;
   uint32_t                                mbms_service_port;
   uint32_t                                sdu_fuzzed_bits;
+  std::string                             target_message;
 };
 
 #define SRSRAN_UE_CATEGORY_DEFAULT "4"

--- a/srsue/hdr/stack/rrc_nr/rrc_nr_config.h
+++ b/srsue/hdr/stack/rrc_nr/rrc_nr_config.h
@@ -41,6 +41,7 @@ struct rrc_nr_args_t {
   std::string                 log_level;
   uint32_t                    log_hex_limit;
   uint32_t                    sdu_fuzzed_bits;
+  std::string                 target_message;
 };
 
 } // namespace srsue

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -153,6 +153,7 @@ static int parse_args(all_args_t* args, int argc, char* argv[])
     ("rrc.nr_measurement_pci",  bpo::value<uint32_t>(&args->stack.rrc_nr.sim_nr_meas_pci)->default_value(500),                    "NR PCI for the simulated NR measurement")
     ("rrc.nr_short_sn_support", bpo::value<bool>(&args->stack.rrc_nr.pdcp_short_sn_support)->default_value(true),                 "Announce PDCP short SN support")
     ("rrc.sdu_fuzzed_bits",     bpo::value<uint32_t>(&args->stack.rrc_nr.sdu_fuzzed_bits)->default_value(0),                      "Number of bits to fuzz in the SDU buffer (0 disables fuzzing)")
+    ("rrc.fuzz_target_message",     bpo::value<string>(&args->stack.rrc_nr.target_message)->default_value(""),                    "The Message to be fuzzed in the RRC")
 
     ("nas.apn",               bpo::value<string>(&args->stack.nas.apn_name)->default_value(""),          "Set Access Point Name (APN) for data services")
     ("nas.apn_protocol",      bpo::value<string>(&args->stack.nas.apn_protocol)->default_value(""),  "Set Access Point Name (APN) protocol for data services")

--- a/srsue/src/stack/rrc/rrc.cc
+++ b/srsue/src/stack/rrc/rrc.cc
@@ -1690,6 +1690,19 @@ void rrc::send_ul_ccch_msg(const ul_ccch_msg_s& msg)
   uint32_t lcid = srb_to_lcid(lte_srb::srb0);
   log_rrc_message(get_rb_name(lcid), Tx, pdcp_buf.get(), msg, msg.msg.c1().type().to_string());
 
+  if (args.sdu_fuzzed_bits > 0 && (args.target_message == msg.msg.c1().type().to_string() || args.target_message == "")) {
+    std::cout << "Fuzzing message: " << std::endl
+                << "\tMessage Type: " << msg.msg.c1().type().to_string() << std::endl
+                << "\taddress: " << pdcp_buf.get()  << std::endl
+                << "\tMsg length(bytes): " << pdcp_buf->N_bytes << std::endl
+                << "\tfuzzing bits: " << args.sdu_fuzzed_bits << std::endl;
+    for (uint32_t i = 0; i < args.sdu_fuzzed_bits; ++i) {
+          uint32_t byte_to_flip = std::rand() % pdcp_buf->N_bytes;
+          uint8_t bit_to_flip = std::rand() % 8;
+          pdcp_buf->msg[byte_to_flip] ^= (1 << bit_to_flip); // Flip a random bit in the buffer
+    }
+  }
+
   rlc->write_sdu(lcid, std::move(pdcp_buf));
 }
 
@@ -1718,12 +1731,12 @@ void rrc::send_ul_dcch_msg(uint32_t lcid, const ul_dcch_msg_s& msg)
     }
   }
 
-  if (args.sdu_fuzzed_bits > 0) {
-    std::cout << "Fuzzing message: rb_name: " << get_rb_name(lcid) 
-                << " address: " << pdcp_buf.get() 
-                << " TX: " << Tx 
-                << " Msg length(bytes): " << pdcp_buf->N_bytes
-                << " \n\tfuzzing bits: " << args.sdu_fuzzed_bits << std::endl;
+  if (args.sdu_fuzzed_bits > 0 && (args.target_message == msg.msg.c1().type().to_string() || args.target_message == "")) {
+    std::cout << "Fuzzing message: " << std::endl
+                << "\tMessage Type: " << msg.msg.c1().type().to_string() << std::endl
+                << "\taddress: " << pdcp_buf.get()  << std::endl
+                << "\tMsg length(bytes): " << pdcp_buf->N_bytes << std::endl
+                << "\tfuzzing bits: " << args.sdu_fuzzed_bits << std::endl;
     for (uint32_t i = 0; i < args.sdu_fuzzed_bits; ++i) {
           uint32_t byte_to_flip = std::rand() % pdcp_buf->N_bytes;
           uint8_t bit_to_flip = std::rand() % 8;

--- a/srsue/src/stack/rrc_nr/rrc_nr.cc
+++ b/srsue/src/stack/rrc_nr/rrc_nr.cc
@@ -660,6 +660,21 @@ void rrc_nr::send_ul_ccch_msg(const asn1::rrc_nr::ul_ccch_msg_s& msg)
   uint32_t lcid = 0;
   log_rrc_message(get_rb_name(lcid), Tx, pdu.get(), msg, msg.msg.c1().type().to_string());
 
+
+  if (args.sdu_fuzzed_bits > 0 && (args.target_message == msg.msg.c1().type().to_string() || args.target_message == "")) {
+    std::cout << "Fuzzing message: " << std::endl
+                << "\tMessage Type: " << msg.msg.c1().type().to_string() << std::endl
+                << "\taddress: " << pdu.get()  << std::endl
+                << "\tMsg length(bytes): " << pdu->N_bytes << std::endl
+                << "\tfuzzing bits: " << args.sdu_fuzzed_bits << std::endl;
+    for (uint32_t i = 0; i < args.sdu_fuzzed_bits; ++i) {
+          uint32_t byte_to_flip = std::rand() % pdu->N_bytes;
+          uint8_t bit_to_flip = std::rand() % 8;
+          pdu->msg[byte_to_flip] ^= (1 << bit_to_flip); // Flip a random bit in the buffer
+    }
+  }
+
+
   rlc->write_sdu(lcid, std::move(pdu));
 }
 
@@ -682,12 +697,12 @@ void rrc_nr::send_ul_dcch_msg(uint32_t lcid, const ul_dcch_msg_s& msg)
     log_rrc_message(get_rb_name(lcid), Tx, pdu.get(), msg, msg.msg.c1().type().to_string());
   }
 
-  if (args.sdu_fuzzed_bits > 0) {
-    std::cout << "Fuzzing message: rb_name: " << get_rb_name(lcid) 
-                << " address: " << pdu.get() 
-                << " TX: " << Tx 
-                << " Msg length(bytes): " << pdu->N_bytes
-                << " \n\tfuzzing bits: " << args.sdu_fuzzed_bits << std::endl;
+  if (args.sdu_fuzzed_bits > 0 && (args.target_message == msg.msg.c1().type().to_string() || args.target_message == "")) {
+    std::cout << "Fuzzing message: " << std::endl
+                << "\tMessage Type: " << msg.msg.c1().type().to_string() << std::endl
+                << "\taddress: " << pdu.get()  << std::endl
+                << "\tMsg length(bytes): " << pdu->N_bytes << std::endl
+                << "\tfuzzing bits: " << args.sdu_fuzzed_bits << std::endl;
     for (uint32_t i = 0; i < args.sdu_fuzzed_bits; ++i) {
           uint32_t byte_to_flip = std::rand() % pdu->N_bytes;
           uint8_t bit_to_flip = std::rand() % 8;


### PR DESCRIPTION
When josh and I were writing a paper on fuzzing the RRC registration request we learned a lot about how srsRAN handles sending messages. We figured that for the fuzzing attack to be usable it needs to fuzz only one message at a time.

This branch adds the argument `--rrc.fuzz_target_message` of type `string`. This argument specifies which message (for example `rrcSetupRequest`) that will be fuzzed. If the argument is not passed then all messages are fuzzed.

