### PR TITLE
Add ZMQ system test CI for rtue + srsgnb

### DIFF
--- a/.github/workflows/ci-system-tests.yaml
+++ b/.github/workflows/ci-system-tests.yaml
@@ -105,7 +105,21 @@ jobs:
       - name: Run system test
         run: |
           sed -i "s|DOCKER_CONTROLLER_INIT_CONFIG=.*|DOCKER_CONTROLLER_INIT_CONFIG=${{ matrix.system_test_config }}|g" .env
-          docker compose up --abort-on-container-exit --exit-code-from controller
+
+          if [ "${{ matrix.system_test_config }}" = "configs/system_tests/zmq_rtue_ci.yaml" ]; then
+            # rtue in this ZMQ scenario is expected to stay alive; bound runtime and verify attach via logs.
+            set +e
+            timeout 180 docker compose up --abort-on-container-exit --exit-code-from controller
+            compose_rc=$?
+            set -e
+
+            if [ "$compose_rc" -ne 0 ] && [ "$compose_rc" -ne 124 ]; then
+              echo "ZMQ compose run failed with unexpected code: $compose_rc"
+              exit "$compose_rc"
+            fi
+          else
+            docker compose up --abort-on-container-exit --exit-code-from controller
+          fi
 
       - name: Verify ZMQ UE connection in gNB logs
         if: always() && matrix.system_test_config == 'configs/system_tests/zmq_rtue_ci.yaml'

--- a/.github/workflows/ci-system-tests.yaml
+++ b/.github/workflows/ci-system-tests.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           docker rm -f srsgnb-ci >/dev/null 2>&1 || true
           docker network inspect rt_zmq >/dev/null 2>&1 || \
-            docker network create --subnet 172.22.0.0/24 --gateway 172.22.0.1 rt_zmq
+            docker network create --subnet 172.22.0.0/24 --gateway 172.22.0.254 rt_zmq
 
           docker run -d \
             --name srsgnb-ci \

--- a/.github/workflows/ci-system-tests.yaml
+++ b/.github/workflows/ci-system-tests.yaml
@@ -46,6 +46,7 @@ jobs:
           - ci_configs/system_environment_tests/test_uhd_images.yaml
           - ci_configs/system_environment_tests/test_influx_access.yaml
           - ci_configs/system_environment_tests/test_conf_pass.yaml
+          - configs/system_tests/zmq_rtue_ci.yaml
 
           # Build tests
           - ci_configs/component_build_tests/test_build_ssb_spoofer.yaml
@@ -73,6 +74,26 @@ jobs:
       - name: Run system setup
         run: ./scripts/system_setup.sh --no-confirm
 
+      - name: Start ZMQ gNB service
+        if: matrix.system_test_config == 'configs/system_tests/zmq_rtue_ci.yaml'
+        run: |
+          docker rm -f srsgnb-ci >/dev/null 2>&1 || true
+          docker network inspect rt_zmq >/dev/null 2>&1 || \
+            docker network create --subnet 172.22.0.0/24 --gateway 172.22.0.1 rt_zmq
+
+          docker run -d \
+            --name srsgnb-ci \
+            --network rt_zmq \
+            --ip 172.22.0.1 \
+            --privileged \
+            -v "${GITHUB_WORKSPACE}/configs/srsran/gnb_zmq_docker.yaml:/gnb.yaml:ro" \
+            ghcr.io/cueltschey/srsgnb \
+            sh -lc "gnb -c /gnb.yaml"
+
+          # Give gNB/open5gs stack time to initialize before starting the UE.
+          sleep 20
+          docker logs srsgnb-ci --tail 100 || true
+
       #- name: Download Docker image artifact
       #  uses: actions/download-artifact@v4
       #  with:
@@ -86,7 +107,24 @@ jobs:
           sed -i "s|DOCKER_CONTROLLER_INIT_CONFIG=.*|DOCKER_CONTROLLER_INIT_CONFIG=${{ matrix.system_test_config }}|g" .env
           docker compose up --abort-on-container-exit --exit-code-from controller
 
+      - name: Verify ZMQ UE connection in gNB logs
+        if: always() && matrix.system_test_config == 'configs/system_tests/zmq_rtue_ci.yaml'
+        run: |
+          docker logs srsgnb-ci > /tmp/srsgnb.log 2>&1 || true
+          tail -n 200 /tmp/srsgnb.log || true
+
+          ATTACH_REGEX='(Registration[[:space:]_-]*Accept|InitialUEMessage|UE[[:space:]_-]*Context|RRC[[:space:]_-]*Setup|PDU[[:space:]_-]*Session)'
+          if ! grep -Eiq "$ATTACH_REGEX" /tmp/srsgnb.log; then
+            echo "Failed to find UE attach/registration evidence in srsgnb logs"
+            exit 1
+          fi
+
       - name: Tear down containers
         if: always()
         run: docker compose down -v
+      - name: Tear down gNB resources
+        if: always()
+        run: |
+          docker rm -f srsgnb-ci >/dev/null 2>&1 || true
+          docker network rm rt_zmq >/dev/null 2>&1 || true
 

--- a/.github/workflows/ci-system-tests.yaml
+++ b/.github/workflows/ci-system-tests.yaml
@@ -71,6 +71,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y uhd-host
 
+      - name: Install gNB emulation dependency
+        if: matrix.system_test_config == 'configs/system_tests/zmq_rtue_ci.yaml'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
       - name: Run system setup
         run: ./scripts/system_setup.sh --no-confirm
 
@@ -86,12 +92,13 @@ jobs:
             --network rt_zmq \
             --ip 172.22.0.1 \
             --privileged \
+            -v /usr/bin/qemu-x86_64-static:/usr/bin/qemu-x86_64-static:ro \
             -v "${GITHUB_WORKSPACE}/configs/srsran/gnb_zmq_docker.yaml:/gnb.yaml:ro" \
             ghcr.io/cueltschey/srsgnb \
-            sh -lc "gnb -c /gnb.yaml"
+            sh -lc "qemu-x86_64-static /usr/local/bin/gnb -c /gnb.yaml"
 
           # Give gNB/open5gs stack time to initialize before starting the UE.
-          sleep 20
+          sleep 40
           docker logs srsgnb-ci --tail 100 || true
 
       #- name: Download Docker image artifact

--- a/configs/system_tests/zmq_rtue_ci.yaml
+++ b/configs/system_tests/zmq_rtue_ci.yaml
@@ -12,4 +12,4 @@ run_spec:
     rf:
       type: "zmq"
       tcp_subnet: "172.22.0.0/24"
-      gateway: "172.22.0.1"
+      gateway: "172.22.0.254"

--- a/configs/system_tests/zmq_rtue_ci.yaml
+++ b/configs/system_tests/zmq_rtue_ci.yaml
@@ -1,0 +1,15 @@
+exit_on_component_failure: true
+
+build_spec:
+  - component: "oran-testing/rtue"
+    branch: "main"
+    pull: true
+
+run_spec:
+  - component: "oran-testing/rtue"
+    name: "rtue_zmq_ci"
+    config_file: "configs/srsran/ue_zmq_docker.conf"
+    rf:
+      type: "zmq"
+      tcp_subnet: "172.22.0.0/24"
+      gateway: "172.22.0.1"


### PR DESCRIPTION
## Summary
- add a ZMQ-based system test spec at configs/system_tests/zmq_rtue_ci.yaml
- register the new system test in the system test CI matrix
- start ghcr.io/cueltschey/srsgnb in CI for this test case
- verify UE attach/registration evidence from gNB logs
- clean up srsgnb container and rt_zmq network in teardown

## Validation
- local YAML/workflow diagnostics show no syntax errors
- full CI to run on this PR
